### PR TITLE
Use storage disk for temporary laserpoint files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ This is the BIIGLE module to perform a heuristic laser point detection on images
 2. Add `Biigle\Modules\Laserpoints\LaserpointsServiceProvider::class` to the `providers` array in `config/app.php`.
 3. Run `php artisan vendor:publish --tag=public` to publish the public assets of this module.
 4. Run `pip install -r vendor/biigle/laserpoints/requirements.txt` to install the Python requirements.
+5. Configure a storage disk for the temporary laserpoints files `LASERPOINTS_DISK` variable to the name of this storage disk in the `.env` file. Example for a local disk:
+    ```php
+    'laserpoints' => [
+        'driver' => 'local',
+        'root' => storage_path('framework/cache/laserpoints'),
+    ],
+    ```
 
 ## References
 

--- a/src/Jobs/ProcessDelphiJob.php
+++ b/src/Jobs/ProcessDelphiJob.php
@@ -5,6 +5,7 @@ namespace Biigle\Modules\Laserpoints\Jobs;
 use App;
 use File;
 use Cache;
+use Storage;
 use Exception;
 use FileCache;
 use Biigle\Jobs\Job as BaseJob;
@@ -55,6 +56,13 @@ class ProcessDelphiJob extends BaseJob implements ShouldQueue
     protected $deleteWhenMissingModels = true;
 
     /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 1;
+
+    /**
      * Create a new job instance.
      *
      * @param Image $image
@@ -66,7 +74,7 @@ class ProcessDelphiJob extends BaseJob implements ShouldQueue
      */
     public function __construct($image, $distance, $gatherFile, $cacheKey = null)
     {
-        $this->image = $image;
+        $this->image = Image::convert($image);
         $this->gatherFile = $gatherFile;
         $this->distance = $distance;
         // If null, this job assumes it is the only one accessing the gatherFile.
@@ -80,18 +88,27 @@ class ProcessDelphiJob extends BaseJob implements ShouldQueue
      */
     public function handle()
     {
+        $tmpDir = config('laserpoints.tmp_dir');
+        $localGatherPath = "{$tmpDir}/{$this->gatherFile}";
+        $stream = Storage::disk(config('laserpoints.disk'))
+            ->readStream($this->gatherFile);
+        File::put($localGatherPath, $stream);
+
+        $callback = function ($image, $path) use ($localGatherPath) {
+            $delphi = App::make(DelphiApply::class);
+
+            return $delphi->execute($localGatherPath, $path, $this->distance);
+        };
 
         try {
-            $output = FileCache::getOnce($this->image, function ($image, $path){
-                $delphi = App::make(DelphiApply::class);
-
-                return $delphi->execute($this->gatherFile, $path, $this->distance);
-            });
+            $output = FileCache::getOnce($this->image, $callback);
         } catch (Exception $e) {
             $output = [
                 'error' => true,
                 'message' => $e->getMessage(),
             ];
+        } finally {
+            File::delete($localGatherPath);
         }
 
         $output['distance'] = $this->distance;
@@ -115,7 +132,7 @@ class ProcessDelphiJob extends BaseJob implements ShouldQueue
     /**
      * Handles the deletion of the gatherFile once all "sibling" jobs finished.
      *
-     * If more than one chunk is processed during a Delphi LP detection, the jobs use the
+     * If more than one image is processed during a Delphi LP detection, the jobs use the
      * cache to track how many of them are still running. They need to track this to
      * determine when the gatherFile can be deleted. This function updates the count
      * when a job was finished and deletes the gather file if this is the last job to
@@ -132,6 +149,6 @@ class ProcessDelphiJob extends BaseJob implements ShouldQueue
             Cache::forget($this->cacheKey);
         }
 
-        File::delete($this->gatherFile);
+        Storage::disk(config('laserpoints.disk'))->delete($this->gatherFile);
     }
 }

--- a/src/Support/DelphiGather.php
+++ b/src/Support/DelphiGather.php
@@ -21,10 +21,8 @@ class DelphiGather
     public function __construct()
     {
         $tmpDir = config('laserpoints.tmp_dir');
-        if (!File::isDirectory($tmpDir)) {
-            File::makeDirectory($tmpDir, 0755, true);
-        }
         $tmpFile = uniqid('biigle_delphi_gather_output_');
+        // Determine only the path of the file as it must not exist initially.
         $this->outputPath = "{$tmpDir}/{$tmpFile}";
     }
 

--- a/src/config/laserpoints.php
+++ b/src/config/laserpoints.php
@@ -28,11 +28,14 @@ return [
     'delphi_apply_script' => __DIR__.'/../resources/scripts/delphi_apply.py',
 
     /*
-    | Directory for temporary files to share data between workers. Note that this
-    | directory must be accessible for all workers! The storage directory might be a
-    | good idea.
+    | Directory for temporary files.
     */
-    'tmp_dir' => storage_path('framework/cache/laserpoints'),
+    'tmp_dir' => sys_get_temp_dir(),
+
+    /*
+    | Storage disk to store Delphi gather files that are shared by queued jobs.
+    */
+    'disk' => env('LASERPOINTS_DISK', 'laserpoints'),
 
     /*
      | Specifies which queue should be used for which job.


### PR DESCRIPTION
Resolves #37

After upgrading to this version, configure a storage disk for the temporary laserpoints files `LASERPOINTS_DISK` variable to the name of this storage disk in the `.env` file. Example for a local disk:
```php
'laserpoints' => [
    'driver' => 'local',
    'root' => storage_path('framework/cache/laserpoints'),
],
```