### PR TITLE
Fix for negative sqrt silently failing

### DIFF
--- a/src/resources/scripts/delphi_apply.py
+++ b/src/resources/scripts/delphi_apply.py
@@ -103,7 +103,15 @@ elif laserpoints.shape[0] == 3:
     s = 1.5 * laserdist
     are = np.sqrt(s * np.power(s - laserdist, 3))
     s = (a + b + c) / 2.
-    apx = np.sqrt(s * (s - a) * (s - b) * (s - c))
+    sqrtinp = s * (s - a) * (s - b) * (s - c)
+    if sqrtinp < 0:
+        print(json.dumps({
+            "error": True,
+            "message": "Computed pixel area is invalid.",
+            "method": detection
+        }))
+        exit(1)
+    apx = np.sqrt(sqrtinp)
     if apx == 0:
         print(json.dumps({
             "error": True,


### PR DESCRIPTION
fixes #35 

It looks like the 3 points in #35 are too close to each other to be valid and thus the input to the sqrt becomes practically zero, but with a negative sign. I added an if to not evaluate this further and throw an error instead.