### PR TITLE
Replace assertEquals by assertSame

### DIFF
--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -35,9 +35,9 @@ class ImageTest extends TestCase
             'attrs' => [Image::LASERPOINTS_ATTRIBUTE => ['area' => 500]],
         ]);
         $laserpointsImage = Image::convert($image);
-        $this->assertEquals($image->id, $laserpointsImage->id);
+        $this->assertSame($image->id, $laserpointsImage->id);
         $this->assertTrue($laserpointsImage instanceof Image);
-        $this->assertEquals(500, $laserpointsImage->laserpoints['area']);
+        $this->assertSame(500, $laserpointsImage->laserpoints['area']);
     }
 
     public function testLaserpoints()
@@ -51,7 +51,7 @@ class ImageTest extends TestCase
         $expect = [
             'area' => 500,
         ];
-        $this->assertEquals($expect, $image->fresh()->laserpoints);
+        $this->assertSame($expect, $image->fresh()->laserpoints);
     }
 
     public function testAreaAttribute()
@@ -63,7 +63,7 @@ class ImageTest extends TestCase
             'area' => 600,
         ];
         $image->save();
-        $this->assertEquals(600, $image->fresh()->area);
+        $this->assertSame(600, $image->fresh()->area);
 
         // Laser point detection overrides the metadata.
         $image->laserpoints = [
@@ -71,7 +71,7 @@ class ImageTest extends TestCase
         ];
         $image->save();
 
-        $this->assertEquals(500, $image->fresh()->area);
+        $this->assertSame(500, $image->fresh()->area);
     }
 
     public function testLaserpointsNotThere()

--- a/tests/Jobs/ProcessDelphiJobTest.php
+++ b/tests/Jobs/ProcessDelphiJobTest.php
@@ -53,17 +53,17 @@ class ProcessDelphiJobTest extends TestCase
         with(new ProcessDelphiJob($this->image, 30, $this->gatherFile))->handle();
 
         $expect = [
+            'error' => false,
             'area' => 100,
             'count' => 3,
             'method' => 'delphi',
             'points' => [[100, 100], [200, 200], [300, 300]],
-            'error' => false,
             'distance' => 30,
         ];
 
-        $this->assertEquals($expect, $this->image->fresh()->laserpoints);
+        $this->assertSame($expect, $this->image->fresh()->laserpoints);
         // Previously set attrs should not be lost.
-        $this->assertEquals(1, $this->image->fresh()->attrs['a']);
+        $this->assertSame(1, $this->image->fresh()->attrs['a']);
     }
 
     public function testHandleGracefulError()
@@ -88,7 +88,7 @@ class ProcessDelphiJobTest extends TestCase
             'distance' => 30,
         ];
 
-        $this->assertEquals($expect, $this->image->fresh()->laserpoints);
+        $this->assertSame($expect, $this->image->fresh()->laserpoints);
     }
 
     public function testHandleFatalError()
@@ -121,6 +121,6 @@ class ProcessDelphiJobTest extends TestCase
             'distance' => 30,
         ];
 
-        $this->assertEquals($expect, $this->image->fresh()->laserpoints);
+        $this->assertSame($expect, $this->image->fresh()->laserpoints);
     }
 }

--- a/tests/Jobs/ProcessManualJobTest.php
+++ b/tests/Jobs/ProcessManualJobTest.php
@@ -44,17 +44,16 @@ class ProcessManualJobTest extends TestCase
         with(new ProcessManualJob($this->image, $this->points, 30))->handle();
 
         $expect = [
+            'error' => false,
             'area' => 100,
             'count' => 3,
             'method' => 'manual',
             'points' => [[100, 100], [200, 200], [300, 300]],
-            'error' => false,
             'distance' => 30,
         ];
-
-        $this->assertEquals($expect, $this->image->fresh()->laserpoints);
+        $this->assertSame($expect, $this->image->fresh()->laserpoints);
         // Previously set attributes should not be lost.
-        $this->assertEquals(1, $this->image->fresh()->attrs['a']);
+        $this->assertSame(1, $this->image->fresh()->attrs['a']);
     }
 
     public function testHandleGracefulError()
@@ -79,7 +78,7 @@ class ProcessManualJobTest extends TestCase
             'distance' => 30,
         ];
 
-        $this->assertEquals($expect, $this->image->fresh()->laserpoints);
+        $this->assertSame($expect, $this->image->fresh()->laserpoints);
     }
 
     public function testHandleFatalError()
@@ -112,6 +111,6 @@ class ProcessManualJobTest extends TestCase
             'distance' => 30,
         ];
 
-        $this->assertEquals($expect, $this->image->fresh()->laserpoints);
+        $this->assertSame($expect, $this->image->fresh()->laserpoints);
     }
 }

--- a/tests/Jobs/ProcessVolumeDelphiJobTest.php
+++ b/tests/Jobs/ProcessVolumeDelphiJobTest.php
@@ -43,7 +43,7 @@ class ProcessVolumeDelphiJobTest extends TestCase
 
 
         $expect = [$image->id => '[[0,0],[0,0],[0,0]]'];
-        $this->assertEquals($expect, $job->points->toArray());
+        $this->assertSame($expect, $job->points->toArray());
 
         Bus::assertBatched(function (PendingBatch $batch) {
             return $batch->jobs->count() === 1 && $batch->jobs[0] instanceof ProcessDelphiJob;

--- a/tests/VolumeTest.php
+++ b/tests/VolumeTest.php
@@ -16,7 +16,7 @@ class VolumeTest extends TestCase
     {
         $volume = BaseVolumeTest::create();
         $laserpointsVolume = Volume::convert($volume);
-        $this->assertEquals($volume->id, $laserpointsVolume->id);
+        $this->assertSame($volume->id, $laserpointsVolume->id);
         $this->assertTrue($laserpointsVolume instanceof Volume);
     }
 


### PR DESCRIPTION
Use assertSame for strong equality checks.

References biigle/core#430.